### PR TITLE
linux: add CTF for the students who already know linux

### DIFF
--- a/topics/linux/code/docker-compose.yml
+++ b/topics/linux/code/docker-compose.yml
@@ -6,3 +6,7 @@ services:
       - ./hello_world_service:/hello_world_service/hello_world_service
       - ./solution:/hello_world_service/solution
     privileged: true
+  learn-linux-by-ctf:
+    image: ghcr.io/bacluc/learn-linux-by-ctf:2024-03
+    profiles:
+      - learn-linux-by-ctf

--- a/topics/linux/linux_exercise.md
+++ b/topics/linux/linux_exercise.md
@@ -148,3 +148,18 @@ Startet der Service auch neu?
 \lstinputlisting{code/solution/update-hello-world-service.sh}
 
 <#endif>
+
+### Learn Linux by Capture the Flag (CTF)
+
+Für die schnellen sind zusätzliche Übungen mit einem Capture the Flag vorbereitet.
+Starte das CTF mit:
+
+```shell
+cd topics/linux/code
+docker compose run learn-linux-by-ctf
+```
+
+Taken from:
+
+- [guye1296/learn-linux-by-ctf](https://github.com/guye1296/learn-linux-by-ctf), Lizenz: [GPL-3.0](https://github.com/guye1296/learn-linux-by-ctf#GPL-3.0-1-ov-file)
+- [fluxkompensat0r/learn-linux-by-ctf](https://github.com/fluxkompensat0r/learn-linux-by-ctf), Lizenz: [GPL-3.0](https://github.com/fluxkompensat0r/learn-linux-by-ctf#GPL-3.0-1-ov-file)


### PR DESCRIPTION
Use docker compose to reference image to facilitate updates in the future with renovate.
The image was build locally for now.
Use a profile that the container does not start with docker compose up -d.
Repo: https://github.com/BacLuc/learn-linux-by-ctf
If it proves useful, we can improve that.