### PR TITLE
add renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,38 @@
+{
+  "extends": [
+    "config:base",
+    ":prConcurrentLimitNone"
+  ],
+  "automergeType": "branch",
+  "labels": [
+    "renovate"
+  ],
+  "packageRules": [
+    {
+      "matchFileNames": [
+        "**/*"
+      ],
+      "enabled": false
+    },
+    {
+      "matchFileNames": [
+        ".github/**/*",
+        "topics/linux/**/*",
+        "topics/testing/**/*"
+      ],
+      "vulnerabilityAlerts": {
+        "automerge": true
+      },
+      "enabled": true
+    },
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "lockFileMaintenance"
+      ],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
It works as you can see here:
https://github.com/BacLuc/jumpstart-docs-renovate/pulls

(tested by running renovate locally, not by installing the app in the github repo, with:
` docker run --rm -e LOG_LEVEL=debug renovate/renovate --token $TOKEN --include-forks true --pr-hourly-limit 0 --pr-concurrent-limit 0 --binary-source install BacLuc/jumpstart-docs-renovate | less`
)