### PR TITLE
testing: update pmd-config

### DIFF
--- a/topics/testing/code/pmd-config.xml
+++ b/topics/testing/code/pmd-config.xml
@@ -28,14 +28,11 @@ under the License.
 
     <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" />
     <rule ref="category/java/bestpractices.xml/CheckResultSet" />
-    <rule ref="category/java/bestpractices.xml/UnusedImports" />
     <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
     <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
 
-    <rule ref="category/java/codestyle.xml/DontImportJavaLang" />
-    <rule ref="category/java/codestyle.xml/DuplicateImports" />
     <rule ref="category/java/codestyle.xml/ExtendsObject" />
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" />
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" />
@@ -57,16 +54,6 @@ under the License.
     <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray" />
     <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices" />
     <rule ref="category/java/errorprone.xml/EmptyCatchBlock" />
-    <rule ref="category/java/errorprone.xml/EmptyFinallyBlock" />
-    <rule ref="category/java/errorprone.xml/EmptyIfStmt" />
-    <rule ref="category/java/errorprone.xml/EmptyInitializer" />
-    <rule ref="category/java/errorprone.xml/EmptyStatementBlock" />
-    <rule ref="category/java/errorprone.xml/EmptyStatementNotInLoop" />
-    <rule ref="category/java/errorprone.xml/EmptySwitchStatements" />
-    <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock" />
-    <rule ref="category/java/errorprone.xml/EmptyTryBlock" />
-    <rule ref="category/java/errorprone.xml/EmptyWhileStmt" />
-    <rule ref="category/java/errorprone.xml/ImportFromSamePackage" />
     <rule ref="category/java/errorprone.xml/JumbledIncrementer" />
     <rule ref="category/java/errorprone.xml/MisplacedNullCheck" />
     <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode" />


### PR DESCRIPTION
Fix warnings for discontinued rules.

[WARNING] Discontinue using Rule name category/java/bestpractices.xml/UnusedImports as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/codestyle.xml/DontImportJavaLang as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/codestyle.xml/DuplicateImports as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyFinallyBlock as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyIfStmt as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyInitializer as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyStatementBlock as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyStatementNotInLoop as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptySwitchStatements as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptySynchronizedBlock as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyTryBlock as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyWhileStmt as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/ImportFromSamePackage as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/bestpractices.xml/UnusedImports as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/codestyle.xml/DontImportJavaLang as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/codestyle.xml/DuplicateImports as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyFinallyBlock as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyIfStmt as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyInitializer as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyStatementBlock as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyStatementNotInLoop as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptySwitchStatements as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptySynchronizedBlock as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyTryBlock as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/EmptyWhileStmt as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule. [WARNING] Discontinue using Rule name category/java/errorprone.xml/ImportFromSamePackage as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule.