### PR TITLE
.devcontainer/java: add GitHub.copilot and codeium extensions

### DIFF
--- a/.devcontainer/java/devcontainer.json
+++ b/.devcontainer/java/devcontainer.json
@@ -10,6 +10,8 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "Codeium.codeium",
+                "GitHub.copilot",
                 "redhat.java",
                 "ryanluker.vscode-coverage-gutters",
                 "ms-vscode.live-server"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,11 @@
 {
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
     "cmake.generator": "Unix Makefiles",
+    "codeium.disableSupercomplete": true,
+    "codeium.enableExplainProblem": false,
+    "codeium.enableInComments": false,
+    "codeium.enableCodeLens": false,
+    "codeium.enableConfig": {
+        "*": false
+    },
 }


### PR DESCRIPTION
The free version of GitHub copilot currently has a limit. 
https://code.visualstudio.com/blogs/2024/12/18/free-github-copilot 
That's why i add Codeium as backup, but disabled it. 
The students often waste time looking up basic
java features, but they should do testing.